### PR TITLE
Fix footer to bottom of page.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,7 +12,9 @@ layout: compress
 	{% endunless %}
 
 	{% include _masthead.html %}
-	{{ content }}
+	<div id="main">
+		{{ content }}
+	</div>
 
 	{% unless page.skip_boilerplate %}
 	{% include _footer.html %}

--- a/_sass/_07_layout.scss
+++ b/_sass/_07_layout.scss
@@ -276,6 +276,8 @@ body.video cite { color: #fff; }
     padding-bottom: 20px;
     background: $footer-bg;
     color: $footer-color;
+    width: 100%;
+    margin-top: auto;
     }
 
     #footer a {
@@ -361,3 +363,20 @@ body.video cite { color: #fff; }
 .pr5  { padding-right: 5px !important; }
 .pr10 { padding-right: 10px !important; }
 .pr20 { padding-right: 20px !important; }
+
+html, body {
+    height: 100%;
+  }
+  
+  body {
+    display: flex;
+    flex-direction: column;
+  }
+  
+  #main {
+    flex: 1 0 auto;
+  }
+  
+  #footer-content {
+    flex-shrink: 0;
+  }


### PR DESCRIPTION
Refactor layout and styling to include a main content section and a fixed footer

- In `_layouts/default.html`, added a `<div id="main">` wrapper around the `{{ content }}` to create a separate section for the main content.
- In `_sass/_07_layout.scss`, added CSS rules to make the footer fixed at the bottom of the page and the main content section take up the remaining space.