### PR TITLE
Update about page with CAuDri-Challenge details and history

### DIFF
--- a/pages/about.md
+++ b/pages/about.md
@@ -20,8 +20,6 @@ Many of the teams now competing in the CAuDri-Challenge previously took part in 
 
 The event was the motivation for students to spend their little free time on their vehicles, without it we had no reason to continue. At a get together at Ulm University in 2023, experiencing cooperation and competition with like minded students once again - the idea to hold our own competition formed as we decided to take matters in our own hands. 
 
-We were allowed to build on the mature regulations of the Carolo-Cup (thank you <3!) which we modified to fit our needs.
-
 ## The CAuDri e.V.
 The CAuDri e.V. ("e. V." meaning *registered association* in German) is the organizer of the CAuDri-Challenge and its the associations purpose to organize the annual challenge. This includes cooperating with teams, institutions and cooperations to host the event, like providing regulated tracks for testing and competing, team ares, prices, moderation and more. Furthermore we want to help new teams on getting started by providing software and hardware resources to lower the beerier of entry.
 

--- a/pages/about.md
+++ b/pages/about.md
@@ -6,6 +6,7 @@ header: no
 image:
     title: caudri_challenge_2023_teamfoto.jpg
 ---
+
 ## The CAuDri-Challenge
 The CAuDri-Challenge aims to provide a community driven platform for students to develop their own autonomous model vehicles and compete in a series of driving challenges.
 Each team designs and builds a 1:10 scale autonomous vehicle that is challenged to navigate complex rural and suburban scenarios, adhering to traffic rules, recognizing road signs, obeying speed limits, and maneuvering around obstacles.
@@ -13,17 +14,18 @@ Each team designs and builds a 1:10 scale autonomous vehicle that is challenged 
 Community is our core principle as we seek to connect inspired individuals and let them compete. This challenge is for the students by the students!
 
 ### Who is it for?
-Everybody is welcome, however typically teams are from european countries and organized at educational institutions e.g. universities or technical colleges. We do not have an age limit and currently do not require any certificate of enrolment, but please refer to the [regulations](/regulations/) for the official requirements.
+Everybody is welcome to participate, however most teams are organized at educational institutions e.g. universities or technical colleges in Europe. 
+We do not have an age limit and currently do not require any certificate of enrollment. Feel free to a look at our [regulations](/regulations/) for the official requirements.
 
 ### Some History
-Many of the teams now competing in the CAuDri-Challenge previously took part in the Carolo-Cup which was a similar student competition hosted annually by the *Fakultät für Elektrotechnik, Informationstechnik, Physik* at the *Technische Universität Braunschweig* for many years. Unfortunately, like so many social events, the covid-19 pandemic made it impossible to host a in person competition. After the last in person Carolo-Cup in 2020, the cup took place as an exclusively online event until was discontinued in 2023. 
+Many of the teams now competing at the CAuDri-Challenge previously participated in the Carolo-Cup, a similar student competition hosted by the *Fakultät für Elektrotechnik, Informationstechnik, Physik* at the *Technische Universität Braunschweig* for many years. 
+Unfortunately, the Covid-19 pandemic made it impossible to host an in-person competition. After the last in-person Carolo-Cup took place in 2020, the event was held entirely online until it was discontinued in 2023. 
 
-The event was the motivation for students to spend their little free time on their vehicles, without it we had no reason to continue. At a get together at Ulm University in 2023, experiencing cooperation and competition with like minded students once again - the idea to hold our own competition formed as we decided to take matters in our own hands. 
+The Carolo-Cup was the motivation for many students to spend their little free time working on their vehicles. Without it, there was no real reason to continue. 
+At a get-together at Ulm University in 2023, experiencing cooperation and competition with like-minded students once again - the idea to host our own competition formed, as we decided to take matters into our own hands.
 
-## The CAuDri e.V.
-The CAuDri e.V. ("e. V." meaning *registered association* in German) is the organizer of the CAuDri-Challenge and its the associations purpose to organize the annual challenge. This includes cooperating with teams, institutions and cooperations to host the event, like providing regulated tracks for testing and competing, team ares, prices, moderation and more. Furthermore we want to help new teams on getting started by providing software and hardware resources to lower the beerier of entry.
-
-
-
-
+## CAuDri e.V.
+We are *CAuDri e.V.*, a registered non-profit organization based in Germany. The organization was founded in 2024 with the goal to host the annual CAuDri-Challenge.
+In cooperation with our teams, partners and institutions, we can provide our participants with regulated tracks for testing, team areas, prices and a platform to compete against each other.
+We also want to help new teams getting started by offering software and hardware resources to lower the entry barrier.
 

--- a/pages/about.md
+++ b/pages/about.md
@@ -6,11 +6,24 @@ header: no
 image:
     title: caudri_challenge_2023_teamfoto.jpg
 ---
+## The CAuDri-Challenge
+The CAuDri-Challenge aims to provide a community driven platform for students to develop their own autonomous model vehicles and compete in a series of driving challenges.
+Each team designs and builds a 1:10 scale autonomous vehicle that is challenged to navigate complex rural and suburban scenarios, adhering to traffic rules, recognizing road signs, obeying speed limits, and maneuvering around obstacles.
 
-The CAuDri-Challenge aims to provide a platform for students to develop their own autonomous model vehicles and compete in a series of driving challenges. 
-Each team will design and build a 1:10 scale autonomous vehicle that can navigate complex rural and suburban scenarios, adhering to traffic rules, recognizing road signs, obeying speed limits, and maneuvering around obstacles.
+Community is our core principle as we seek to connect inspired individuals and let them compete. This challenge is for the students by the students!
 
-Join our Discord server and stay up to date with the latest news and announcements: [{{site.caudri.discord_invite}}]({{site.caudri.discord_invite}})
+### Who is it for?
+Everybody is welcome, however typically teams are from european countries and organized at educational institutions e.g. universities or technical colleges. We do not have an age limit and currently do not require any certificate of enrolment, but please refer to the [regulations](/regulations/) for the official requirements.
+
+### Some History
+Many of the teams now competing in the CAuDri-Challenge previously took part in the Carolo-Cup which was a similar student competition hosted annually by the *Fakultät für Elektrotechnik, Informationstechnik, Physik* at the *Technische Universität Braunschweig* for many years. Unfortunately, like so many social events, the covid-19 pandemic made it impossible to host a in person competition. After the last in person Carolo-Cup in 2020, the cup took place as an exclusively online event until was discontinued in 2023. 
+
+The event was the motivation for students to spend their little free time on their vehicles, without it we had no reason to continue. At a get together at Ulm University in 2023, experiencing cooperation and competition with like minded students once again - the idea to hold our own competition formed as we decided to take matters in our own hands. 
+
+We were allowed to build on the mature regulations of the Carolo-Cup (thank you <3!) which we modified to fit our needs.
+
+## The CAuDri e.V.
+The CAuDri e.V. ("e. V." meaning *registered association* in German) is the organizer of the CAuDri-Challenge and its the associations purpose to organize the annual challenge. This includes cooperating with teams, institutions and cooperations to host the event, like providing regulated tracks for testing and competing, team ares, prices, moderation and more. Furthermore we want to help new teams on getting started by providing software and hardware resources to lower the beerier of entry.
 
 
 

--- a/pages/about.md
+++ b/pages/about.md
@@ -15,7 +15,7 @@ Community is our core principle as we seek to connect inspired individuals and l
 
 ### Who is it for?
 Everybody is welcome to participate, however most teams are organized at educational institutions e.g. universities or technical colleges in Europe. 
-We do not have an age limit and currently do not require any certificate of enrollment. Feel free to a look at our [regulations](/regulations/) for the official requirements.
+We do not have an age limit and currently do not require any certificate of enrollment. Feel free to take a look at our [regulations](/regulations/) for the official requirements.
 
 ### Some History
 Many of the teams now competing at the CAuDri-Challenge previously participated in the Carolo-Cup, a similar student competition hosted by the *Fakultät für Elektrotechnik, Informationstechnik, Physik* at the *Technische Universität Braunschweig* for many years. 


### PR DESCRIPTION
**_Please review the changes to the text (included below) and scan for any wrong facts or inappropriate comments._**

## The CAuDri-Challenge
The CAuDri-Challenge aims to provide a community driven platform for students to develop their own autonomous model vehicles and compete in a series of driving challenges.
Each team designs and builds a 1:10 scale autonomous vehicle that is challenged to navigate complex rural and suburban scenarios, adhering to traffic rules, recognizing road signs, obeying speed limits, and maneuvering around obstacles.

Community is our core principle as we seek to connect inspired individuals and let them compete. This challenge is for the students by the students!

### Who is it for?
Everybody is welcome, however typically teams are from european countries and organized at educational institutions e.g. universities or technical colleges. We do not have an age limit and currently do not require any certificate of enrolment, but please refer to the [regulations](/regulations/) for the official requirements.

### Some History
Many of the teams now competing in the CAuDri-Challenge previously took part in the Carolo-Cup which was a similar student competition hosted annually by the *Fakultät für Elektrotechnik, Informationstechnik, Physik* at the *Technische Universität Braunschweig* for many years. Unfortunately, like so many social events, the covid-19 pandemic made it impossible to host a in person competition. After the last in person Carolo-Cup in 2020, the cup took place as an exclusively online event until was discontinued in 2023. 

The event was the motivation for students to spend their little free time on their vehicles, without it we had no reason to continue. At a get together at Ulm University in 2023, experiencing cooperation and competition with like minded students once again - the idea to hold our own competition formed as we decided to take matters in our own hands. 

We were allowed to build on the mature regulations of the Carolo-Cup (thank you <3!) which we modified to fit our needs.

## The CAuDri e.V.
The CAuDri e.V. ("e. V." meaning *registered association* in German) is the organizer of the CAuDri-Challenge and its the associations purpose to organize the annual challenge. This includes cooperating with teams, institutions and cooperations to host the event, like providing regulated tracks for testing and competing, team ares, prices, moderation and more. Furthermore we want to help new teams on getting started by providing software and hardware resources to lower the beerier of entry.